### PR TITLE
Fix StringIndexOutOfBoundsException when get the input value from collection

### DIFF
--- a/streaming/src/main/scala/org/apache/carbondata/streaming/parser/FieldConverter.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/parser/FieldConverter.scala
@@ -72,7 +72,11 @@ object FieldConverter {
               timeStampFormat, dateFormat, isVarcharType, level + 1))
               .append(delimiter)
           }
-          builder.substring(0, builder.length - delimiter.length())
+          if(builder.length == 0) {
+            builder.toString()
+          } else {
+            builder.substring(0, builder.length - delimiter.length())
+          }
         // First convert the 'key' of Map and then append the keyValueDelimiter and then convert
         // the 'value of the map and append delimiter
         case m: scala.collection.Map[_, _] =>
@@ -87,8 +91,12 @@ object FieldConverter {
               timeStampFormat, dateFormat, isVarcharType, level + 2))
               .append(delimiter)
           }
-          builder.substring(0, builder.length - delimiter.length())
-        case r: org.apache.spark.sql.Row =>
+          if(builder.length == 0) {
+            builder.toString()
+          } else {
+            builder.substring(0, builder.length - delimiter.length())
+          }
+         case r: org.apache.spark.sql.Row =>
           val delimiter = complexDelimiters.get(level)
           val builder = new StringBuilder()
           for (i <- 0 until r.length) {
@@ -96,8 +104,12 @@ object FieldConverter {
               timeStampFormat, dateFormat, isVarcharType, level + 1))
               .append(delimiter)
           }
-          builder.substring(0, builder.length - delimiter.length())
-        case other => other.toString
+          if(builder.length == 0) {
+            builder.toString()
+          } else {
+            builder.substring(0, builder.length - delimiter.length())
+          }
+         case other => other.toString
       }
     }
   }


### PR DESCRIPTION
…lection

If the collection is empty,  the substring operation(builder.substring(0, builder.length - delimiter.length())) will throw StringIndexOutOfBoundsException.And the 1.5.x version all has this problem.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

